### PR TITLE
Descriptive error message for unknown audio nodes

### DIFF
--- a/src/VirtualAudioNodes/StandardVirtualAudioNode.ts
+++ b/src/VirtualAudioNodes/StandardVirtualAudioNode.ts
@@ -8,9 +8,13 @@ import {
 
 const createAudioNode = (audioContext, name, constructorParam, {offsetTime, startTime, stopTime}) => {
   offsetTime = offsetTime || 0
+  const func = `create${capitalize(name)}`
+  if (typeof audioContext[func] !== 'function') { throw new Error(`Unknown node type: ${name}`) }
+
   const audioNode = constructorParam
-    ? audioContext[`create${capitalize(name)}`](constructorParam)
-    : audioContext[`create${capitalize(name)}`]()
+    ? audioContext[func](constructorParam)
+    : audioContext[func]()
+
   if (startAndStopNodes.indexOf(name) !== -1) {
     if (startTime == null) audioNode.start(audioContext.currentTime, offsetTime); else audioNode.start(startTime, offsetTime)
     if (stopTime != null) audioNode.stop(stopTime)


### PR DESCRIPTION
If a node type is misspelled, we currently get an error like this: `TypeError: audioContext[("create" + capitalize(...))] is not a function`

Instead we can check first and make the error a little more descriptive.

PS. thanks for this library!