### PR TITLE
Node Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ virtual-audio-graph is the core audio library in [Andromeda](https://github.com/
 ### Creating a new virtual-audio-graph
 
 ```javascript
-
 import createVirtualAudioGraph from 'virtual-audio-graph'
 
 const audioContext = new AudioContext()
@@ -44,7 +43,12 @@ const virtualAudioGraph = createVirtualAudioGraph({
   audioContext,
   output: audioContext.destination,
 })
+```
 
+If using commonJS:
+
+```javascript
+const createVirtualAudioGraph = require('virtual-audio-graph').default
 ```
 
 The `createVirtualAudioGraph` factory takes an object with two optional properties:
@@ -67,28 +71,29 @@ The `createVirtualAudioGraph` factory takes an object with two optional properti
 Here we create two oscillators, schedule their start and stop times, put them through a gain node and attach the gain node to the destination:
 
 ```javascript
+import createVirtualAudioGraph, {gain, oscillator} from 'virtual-audio-graph'
 
+const virtualAudioGraph = createVirtualAudioGraph()
 const {currentTime} = virtualAudioGraph
 
 const graph = {
-  0: ['gain', 'output', {gain: 0.2}],
-  1: ['oscillator', 0, {
+  0: gain('output', {gain: 0.2}),
+  1: oscillator(0, {
     type: 'square',
     frequency: 440,
     startTime: currentTime + 1,
     stopTime: currentTime + 2
-  }],
-  2: ['oscillator', 0, {
+  }),
+  2: oscillator(0, {
     type: 'sawtooth',
     frequency: 660,
     detune: 4,
     startTime: currentTime + 1.5,
     stopTime: currentTime + 2.5
-  }],
+  }),
 }
 
 virtualAudioGraph.update(graph)
-
 ```
 
 OK, so what's going on here?
@@ -114,11 +119,11 @@ The above information should be enough to get started creating very simple audio
   ```javascript
   virtualAudioGraph.update({
     // output is a reserved value for virtual-audio-graph destination
-    0: ['oscillator', 'output'],
+    0: oscillator('output'),
     // connecting to the frequency AudioParam of the oscillator above
-    1: ['gain', {key: 0, destination: 'frequency'}, {gain: 10}],
+    1: gain({key: 0, destination: 'frequency'}, {gain: 10}),
     // connect to node key 1 (gain node above) and output
-    2: ['oscillator', [1, 'output'], {type: 'triangle', frequency: 1}],
+    2: oscillator([1, 'output'], {type: 'triangle', frequency: 1}),
   })
   ```
 
@@ -126,59 +131,69 @@ The above information should be enough to get started creating very simple audio
   - specify an ordinary value
   ```javascript
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: 0.5}],
+    0: gain('output', {gain: 0.5}),
   })
   ```
   - specify setValueAtTime
   ```javascript
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: ['setValueAtTime', 0.5, 1]}],
+    0: gain('output', {gain: ['setValueAtTime', 0.5, 1]}),
   })
   ```
   - specify setValueAtTime multiple times
   ```javascript
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
-      ['setValueAtTime', 0, 0],
-      ['setValueAtTime', 1, 1],
-      ['setValueAtTime', 0.5, 2],
-    ]}],
+    0: gain('output', {
+      gain: [
+        ['setValueAtTime', 0, 0],
+        ['setValueAtTime', 1, 1],
+        ['setValueAtTime', 0.5, 2],
+      ],
+    }),
   })
   ```
   - linearRampToValueAtTime
   ```javascript
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
-      ['setValueAtTime', 0, 0],
-      ['linearRampToValueAtTime', 1, 1],
-    ]}],
+    0: gain('output', {
+      gain: [
+        ['setValueAtTime', 0, 0],
+        ['linearRampToValueAtTime', 1, 1],
+      ],
+    }),
   })
   ```
   - exponentialRampToValueAtTime
   ```javascript
   virtualAudioGraph.update({
-    0: ['oscillator', 'output', {frequency: [
-      ['setValueAtTime', 440, 0],
-      ['exponentialRampToValueAtTime', 880, 1],
-    ]}],
+    0: oscillator('output', {
+      frequency: [
+        ['setValueAtTime', 440, 0],
+        ['exponentialRampToValueAtTime', 880, 1],
+      ],
+    }),
   })
   ```
   - setTargetAtTime
   ```javascript
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
-      ['setValueAtTime', 0, 0],
-      ['setTargetAtTime', 1, 1, 0.5],
-    ]}],
+    0: gain('output', {
+      gain: [
+        ['setValueAtTime', 0, 0],
+        ['setTargetAtTime', 1, 1, 0.5],
+      ],
+    }),
   })
   ```
   - setValueCurveAtTime
   ```javascript
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
-      ['setValueAtTime', 0, 0],
-      ['setValueCurveAtTime', Float32Array.of(0.5, 0.75, 0.25, 1), 1, 1],
-    ]}],
+    0: gain('output', {
+      gain: [
+        ['setValueAtTime', 0, 0],
+        ['setValueCurveAtTime', Float32Array.of(0.5, 0.75, 0.25, 1), 1, 1],
+      ],
+    }),
   })
   ```
 
@@ -191,28 +206,30 @@ The virtual audio graph is composed of standard nodes (see [below](#standard-nod
 Specify the node input destination using the string `'input'` as the 4th element in the node array as below:
 
 ```javascript
+import {createNode, delay, gain, oscillator, stereoPanner} from 'virtual-audio-graph'
 
-const pingPongDelay = ({
+const pingPongDelay = createNode(({
   decay = 1 / 3,
   delayTime = 1 / 3,
   maxDelayTime = 1 / 3,
 } = {}) => ({
-  zero: ['stereoPanner', 'output', {pan: -1}],
-  1: ['stereoPanner', 'output', {pan: 1}],
-  2: ['delay', [1, 'five'], {delayTime, maxDelayTime}],
-  3: ['gain', 2, {gain: decay}],
-  4: ['delay', ['zero', 3], {delayTime, maxDelayTime}],
-  five: ['gain', 4, {gain: decay}, 'input'] // note this is the destination for nodes which connect to pingPongDelay
-})
+  0: stereoPanner('output', {pan: -1}),
+  1: stereoPanner('output', {pan: 1}),
+  2: delay([1, 'five'], {delayTime, maxDelayTime}),
+  3: gain(2, {gain: decay}),
+  4: delay([0, 3], {delayTime, maxDelayTime}),
+  five: gain(4, {gain: decay}, 'input') // note this is the destination for nodes which connect to pingPongDelay
+}))
 
 // and now virtual-audio-graph will recognize it as a valid node:
 virtualAudioGraph.update({
-  0: [pingPongDelay,
-      'output',
-      // the below parameters are passed into the pingPongDelay function declared above
-      {decay: 1 / 4, delayTime: 1 / 3, maxDelayTime: 1}],
-  1: ['gain', [0, 'output'], {gain: 1 / 4}],
-  2: ['oscillator', 1, {frequency: 440, type: 'square'}],
+  0: pingPongDelay(
+    'output',
+    // the below parameters are passed into the pingPongDelay function declared above
+    {decay: 1 / 4, delayTime: 1 / 3, maxDelayTime: 1},
+  ),
+  1: gain([0, 'output'], {gain: 1 / 4}),
+  2: oscillator(1, {frequency: 440, type: 'square'}),
 })
 
 ```
@@ -220,29 +237,31 @@ virtualAudioGraph.update({
 If an `'input'` node has no parameters specify `null` like this:
 
 ```javascript
-  five: ['gain', 4, null, 'input']
+  five: gain(4, null, 'input')
 ```
 
 ### Standard Nodes
 
 Here is a list of standard nodes implemented in virtual-audio-graph and the params you can provide them with. You can build custom nodes out of these as above.
 
-#### [AnalyserNode](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode)
+#### [analyser](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode)
 
 ```javascript
-['analyser', output, {fftSize,
-                      minDecibels,
-                      maxDecibels,
-                      smoothingTimeConstant}]
+analyser(output, {
+  fftSize,
+  minDecibels,
+  maxDecibels,
+  smoothingTimeConstant,
+}]
 ```
 ___
 
-#### [AudioBufferSourceNode](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode)
+#### [bufferSource](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode)
 
 ```javascript
 const {audioContext, audioContext: {sampleRate}} = virtualAudioGraph
 const buffer = audioContext.createBuffer(2, sampleRate * 2, sampleRate)
-['bufferSource', output, {
+bufferSource(output, {
   buffer,
   loop,
   loopEnd,
@@ -258,85 +277,90 @@ const buffer = audioContext.createBuffer(2, sampleRate * 2, sampleRate)
   // if not provided then stop is not called on node
   // until it is disconnected
   stopTime
-}]
+})
 ```
 ___
 
-#### [BiquadFilterNode](https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode)
-
-```javascript
-['biquadFilter', output, {type, frequency, detune, Q}]
-```
-___
-#### [ChannelMergerNode](https://developer.mozilla.org/en-US/docs/Web/API/ChannelMergerNode)
+#### [biquadFilter](https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode)
 
 ```javascript
-['channelMerger', output, {numberOfOutputs}]
+biquadFilter(output, {type, frequency, detune, Q})
 ```
 ___
-#### [ChannelSplitterNode](https://developer.mozilla.org/en-US/docs/Web/API/ChannelSplitterNode)
+#### [channelMerger](https://developer.mozilla.org/en-US/docs/Web/API/ChannelMergerNode)
+
+```javascript
+channelMerger(output, {numberOfOutputs})
+```
+___
+#### [channelSplitter](https://developer.mozilla.org/en-US/docs/Web/API/ChannelSplitterNode)
 
 NB ChannelSplitter has it's own syntax for the output parameter. Because the channel is split it means each node can have multiple outputs. Each output is indexed and the outputs property should be an array of these indices. Then the inputs property should be an array of indices corresponding to the inputs of the destination node. Check out the spec and the link above for more info.
 
 ```javascript
-['channelSplitter', {key, outputs, inputs}, {numberOfOutputs}]
+channelSplitter({key, outputs, inputs}, {numberOfOutputs})
 ```
 ___
-#### [ConvolverNode](https://developer.mozilla.org/en-US/docs/Web/API/ConvolverNode)
+#### [convolver](https://developer.mozilla.org/en-US/docs/Web/API/ConvolverNode)
 
 ```javascript
-['convolver', output, {buffer, normalize}]
+convolver(output, {buffer, normalize})
 ```
 ___
 
-#### [DelayNode](https://developer.mozilla.org/en-US/docs/Web/API/DelayNode)
+#### [delay](https://developer.mozilla.org/en-US/docs/Web/API/DelayNode)
 NB maxDelayTime must be set when node is first created but cannot be updated. A new node will have to be inserted if a different maxDelayTime is required.
 
 ```javascript
-['delay', output, {delayTime, maxDelayTime}]
+delay(output, {delayTime, maxDelayTime})
 ```
 ___
 
-#### [DynamicsCompressorNode](https://developer.mozilla.org/en-US/docs/Web/API/DynamicsCompressorNode)
+#### [dynamicsCompressor](https://developer.mozilla.org/en-US/docs/Web/API/DynamicsCompressorNode)
 
 ```javascript
-['dynamicsCompressor', output, {attack,
-                                knee,
-                                ratio,
-                                reduction,
-                                release,
-                                threshold}]
-```
-___
-
-#### [GainNode](https://developer.mozilla.org/en-US/docs/Web/API/GainNode)
-
-```javascript
-['gain', output, {gain}]
-```
-___
-#### [MediaStreamAudioDestinationNode](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamAudioDestinationNode)
-
-This node has no output as it is a destination. It also takes no parameters. Use virtualAudioGraph.getAudioNodeById method to access the node's stream property
-
-```javascript
-['mediaStreamDestination']
-```
-___
-#### [MediaStreamAudioSourceNode](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamAudioSourceNode)
-NB Both params can only be set once and only one should be set
-```javascript
-['mediaElementSource', output, {
-  mediaElement, // EITHER set this if constructing from an HTMLMediaElement
-  mediaStream, // OR set this if constructing from a MediaStream
+dynamicsCompressor(output, {
+  attack,
+  knee,
+  ratio,
+  reduction,
+  release,
+  threshold,
 }]
 ```
 ___
 
-#### [OscillatorNode](https://developer.mozilla.org/en-US/docs/Web/API/OscillatorNode)
+#### [gain](https://developer.mozilla.org/en-US/docs/Web/API/GainNode)
 
 ```javascript
-['oscillator', output, {
+gain(output, {gain})
+```
+___
+#### [mediaElementSource](https://developer.mozilla.org/en-US/docs/Web/API/MediaElementAudioSourceNode)
+NB params can only be set once
+```javascript
+mediaElementSource(output, {mediaElement})
+```
+___
+#### [mediaStreamDestination](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamAudioDestinationNode)
+
+This node has no output as it is a destination. It also takes no parameters. Use virtualAudioGraph.getAudioNodeById method to access the node's stream property
+
+```javascript
+mediaStreamDestination()
+```
+___
+#### [mediaStreamSource](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamAudioSourceNode)
+NB params can only be set once
+```javascript
+mediaStreamSource(output, {mediaStream})
+```
+___
+
+#### [oscillator](https://developer.mozilla.org/en-US/docs/Web/API/OscillatorNode)
+
+```javascript
+oscillator(output, {
   type,
   frequency,
   detune,
@@ -345,14 +369,14 @@ ___
   startTime,
   // if not provided then stop is not called on node until it is disconnected
   stopTime,
-}]
+})
 ```
 ___
 
-#### [PannerNode](https://developer.mozilla.org/en-US/docs/Web/API/PannerNode)
+#### [panner](https://developer.mozilla.org/en-US/docs/Web/API/PannerNode)
 
 ```javascript
-['panner', output, {
+panner(output, {
   coneInnerAngle,
   coneOuterAngle,
   coneOuterGain,
@@ -365,19 +389,19 @@ ___
   maxDistance,
   refDistance,
   rolloffFactor,
-}]
+})
 ```
 ___
 
-#### [StereoPannerNode](https://developer.mozilla.org/en-US/docs/Web/API/StereoPannerNode)
+#### [stereoPanner](https://developer.mozilla.org/en-US/docs/Web/API/StereoPannerNode)
 
 ```javascript
-['stereoPanner', output, {pan}]
+stereoPanner(output, {pan})
 ```
 ___
 
-#### [WaveShaperNode](https://developer.mozilla.org/en-US/docs/Web/API/WaveShaperNode)
+#### [waveShaper](https://developer.mozilla.org/en-US/docs/Web/API/WaveShaperNode)
 
 ```javascript
-['waveShaper', output, {curve, oversample}]
+waveShaper(output, {curve, oversample})
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,22 +12,37 @@
   <section>
     <h2>Example 1</h2>
     <pre>
-const {currentTime} = virtualAudioGraph
+import createVirtualAudioGraph, {
+  createNode,
+  delay,
+  gain,
+  oscillator,
+  stereoPanner,
+} from '../src/index'
+
+const audioContext = new AudioContext()
+
+const virtualAudioGraph = createVirtualAudioGraph({
+  audioContext,
+  output: audioContext.destination,
+})
+
+const { currentTime } = virtualAudioGraph
 
 virtualAudioGraph.update({
-  0: ['gain', 'output', {gain: 0.2}],
-  1: ['oscillator', 0, {
+  0: gain('output', { gain: 0.2 }),
+  1: oscillator(0, {
     frequency: 440,
     stopTime: currentTime + 1,
     type: 'square',
-  }],
-  2: ['oscillator', 0, {
+  }),
+  2: oscillator(0, {
     detune: 4,
     frequency: 660,
     startTime: currentTime + 0.5,
     stopTime: currentTime + 1.5,
     type: 'sawtooth',
-  }],
+  }),
 })
     </pre>
     <button id="example1">Play</button>
@@ -36,13 +51,13 @@ virtualAudioGraph.update({
   <section>
     <h2>Example 2</h2>
     <pre>
-const {currentTime} = virtualAudioGraph
+const { currentTime } = virtualAudioGraph
 
 virtualAudioGraph.update({
-  0: ['gain', 'output', {gain: 0.2}],
-  1: ['oscillator', 0, {stopTime: currentTime + 3}],
-  2: ['gain', {destination: 'frequency', key: 1}, {gain: 10}],
-  3: ['oscillator', [2, 'output'], {frequency: 1, type: 'triangle'}],
+  0: gain('output', { gain: 0.2 }),
+  1: oscillator(0, { stopTime: currentTime + 3 }),
+  2: gain({ destination: 'frequency', key: '1' }, { gain: 10 }),
+  3: oscillator([2, 'output'], { frequency: 1, type: 'triangle' }),
 })
     </pre>
     <button id="example2">Play</button>
@@ -53,48 +68,51 @@ virtualAudioGraph.update({
     <pre>
 const chromaticScale = n => 440 * Math.pow(2, n / 12)
 
-const pingPongDelay = ({
+const pingPongDelay = createNode(({
   decay,
   delayTime,
 }) => ({
-  0: ['stereoPanner', 'output', {pan: -1}],
-  1: ['stereoPanner', 'output', {pan: 1}],
-  2: ['delay', [1, 'five'], {delayTime, maxDelayTime: delayTime}],
-  3: ['gain', 2, {gain: decay}],
-  4: ['delay', [0, 3], {delayTime, maxDelayTime: delayTime}],
-  five: ['gain', 4, {gain: decay}, 'input'],
-})
+  0: stereoPanner('output', { pan: -1 }),
+  1: stereoPanner('output', { pan: 1 }),
+  2: delay([1, 'five'], { delayTime, maxDelayTime: delayTime }),
+  3: gain(2, { gain: decay }),
+  4: delay([0, 3], { delayTime, maxDelayTime: delayTime }),
+  five: gain(4, { gain: decay }, 'input'),
+}))
 
-const oscillators = ({
+const oscillators = createNode(({
   currentTime = virtualAudioGraph.currentTime,
   notes,
   noteLength,
-}) => notes.reduce((acc, frequency, i) => {
-  const startTime = currentTime + noteLength * 2 * i
-  acc[i] = ['oscillator', 'output', {
-    frequency,
-    startTime,
-    stopTime: startTime + noteLength,
-  }]
-  return acc
-}, {})
+}) => notes.reduce(
+  (acc, frequency, i) => {
+    const startTime = currentTime + noteLength * 2 * i
+    acc[i] = oscillator('output', {
+      frequency,
+      startTime,
+      stopTime: startTime + noteLength,
+    })
+    return acc
+  },
+  {}),
+)
 
 const noteLength = 0.075
 
-const up = Array.from({length: 16}, (_, i) => chromaticScale(i))
+const up = Array.apply(null, { length: 16 }).map((_, i) => chromaticScale(i))
 const down = [...up].reverse()
 
 virtualAudioGraph.update({
-  0: ['gain', 'output', {gain: 0.2}],
-  1: [pingPongDelay, 0, {
+  0: gain('output', { gain: 0.2 }),
+  1: pingPongDelay(0, {
     decay: 1 / 2,
     delayTime: noteLength * 3 / 2,
-  }],
-  2: ['gain', [0, 1], {gain: 1 / 4}],
-  3: [oscillators, [0, 1], {
+  }),
+  2: gain([0, 1], { gain: 1 / 4 }),
+  3: oscillators([0, 1], {
     noteLength,
     notes: [...up, ...down],
-  }],
+  }),
 })
     </pre>
     <button id="example3">Play</button>

--- a/docsSrc/main.ts
+++ b/docsSrc/main.ts
@@ -1,4 +1,10 @@
-import createVirtualAudioGraph from '../src/index'
+import createVirtualAudioGraph, {
+  createNode,
+  delay,
+  gain,
+  oscillator,
+  stereoPanner,
+} from '../src/index'
 
 const audioContext = new AudioContext()
 
@@ -8,81 +14,84 @@ const virtualAudioGraph = createVirtualAudioGraph({
 })
 
 const example1 = () => {
-  const {currentTime} = virtualAudioGraph
+  const { currentTime } = virtualAudioGraph
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: 0.2}],
-    1: ['oscillator', 0, {
+    0: gain('output', { gain: 0.2 }),
+    1: oscillator(0, {
       frequency: 440,
       stopTime: currentTime + 1,
       type: 'square',
-    }],
-    2: ['oscillator', 0, {
+    }),
+    2: oscillator(0, {
       detune: 4,
       frequency: 660,
       startTime: currentTime + 0.5,
       stopTime: currentTime + 1.5,
       type: 'sawtooth',
-    }],
+    }),
   })
 }
 
 const example2 = () => {
-  const {currentTime} = virtualAudioGraph
+  const { currentTime } = virtualAudioGraph
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: 0.2}],
-    1: ['oscillator', 0, {stopTime: currentTime + 3}],
-    2: ['gain', {destination: 'frequency', key: 1}, {gain: 10}],
-    3: ['oscillator', [2, 'output'], {frequency: 1, type: 'triangle'}],
+    0: gain('output', { gain: 0.2 }),
+    1: oscillator(0, { stopTime: currentTime + 3 }),
+    2: gain({ destination: 'frequency', key: '1' }, { gain: 10 }),
+    3: oscillator([2, 'output'], { frequency: 1, type: 'triangle' }),
   })
 }
 
 const example3 = () => {
   const chromaticScale = n => 440 * Math.pow(2, n / 12)
 
-  const pingPongDelay = ({
+  const pingPongDelay = createNode(({
     decay,
     delayTime,
   }) => ({
-    0: ['stereoPanner', 'output', {pan: -1}],
-    1: ['stereoPanner', 'output', {pan: 1}],
-    2: ['delay', [1, 'five'], {delayTime, maxDelayTime: delayTime}],
-    3: ['gain', 2, {gain: decay}],
-    4: ['delay', [0, 3], {delayTime, maxDelayTime: delayTime}],
-    five: ['gain', 4, {gain: decay}, 'input'],
-  })
+    0: stereoPanner('output', { pan: -1 }),
+    1: stereoPanner('output', { pan: 1 }),
+    2: delay([1, 'five'], { delayTime, maxDelayTime: delayTime }),
+    3: gain(2, { gain: decay }),
+    4: delay([0, 3], { delayTime, maxDelayTime: delayTime }),
+    five: gain(4, { gain: decay }, 'input'),
+  }))
 
-  const oscillators = ({
+  const oscillators = createNode(({
     currentTime = virtualAudioGraph.currentTime,
     notes,
     noteLength,
-  }) => notes.reduce((acc, frequency, i) => {
-    const startTime = currentTime + noteLength * 2 * i
-    acc[i] = ['oscillator', 'output', {
-      frequency,
-      startTime,
-      stopTime: startTime + noteLength,
-    }]
-    return acc
-  }, {})
+  }) => notes.reduce(
+    (acc, frequency, i) => {
+      const startTime = currentTime + noteLength * 2 * i
+      acc[i] = oscillator('output', {
+        frequency,
+        startTime,
+        stopTime: startTime + noteLength,
+      })
+      return acc
+    },
+    {}),
+  )
 
   const noteLength = 0.075
 
-  const up = Array.apply(null, {length: 16}).map((_, i) => chromaticScale(i))
+  const up = Array.apply(null, { length: 16 }).map((_, i) => chromaticScale(i))
   const down = [...up].reverse()
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: 0.2}],
-    1: [pingPongDelay, 0, {
+    0: gain('output', { gain: 0.2 }),
+    1: pingPongDelay(0, {
       decay: 1 / 2,
       delayTime: noteLength * 3 / 2,
-    }],
-    2: ['gain', [0, 1], {gain: 1 / 4}],
-    3: [oscillators, [0, 1], {
+    }),
+    2: gain([0, 1], { gain: 1 / 4 }),
+    3: oscillators([0, 1], {
       noteLength,
       notes: [...up, ...down],
-    }],
+    }),
   })
 }
 

--- a/src/connectAudioNodes.ts
+++ b/src/connectAudioNodes.ts
@@ -1,5 +1,5 @@
 import { entries, values } from './utils'
-import { VirtualAudioNode, VirtualAudioNodeGraph } from './types'
+import { AudioNodePropertyLookup, VirtualAudioNode, VirtualAudioNodeGraph } from './types'
 import CustomVirtualAudioNode from './VirtualAudioNodes/CustomVirtualAudioNode'
 import StandardVirtualAudioNode from './VirtualAudioNodes/StandardVirtualAudioNode'
 
@@ -31,7 +31,7 @@ export default (
           }
           continue
         }
-        virtualNode.connect(virtualGraph[key].audioNode[destination])
+        virtualNode.connect((virtualGraph[key].audioNode as AudioNodePropertyLookup)[destination])
         continue
       }
 

--- a/src/createNode.ts
+++ b/src/createNode.ts
@@ -1,0 +1,6 @@
+import CustomVirtualAudioNode from './VirtualAudioNodes/CustomVirtualAudioNode'
+import { CustomVirtualAudioNodeFactory, Output, VirtualAudioNodeParams } from './types'
+
+export default (node: CustomVirtualAudioNodeFactory) =>
+  (output: Output, params: VirtualAudioNodeParams) =>
+    new CustomVirtualAudioNode(node, output, params)

--- a/src/createVirtualAudioNode.ts
+++ b/src/createVirtualAudioNode.ts
@@ -1,8 +1,0 @@
-import StandardVirtualAudioNode from './VirtualAudioNodes/StandardVirtualAudioNode'
-import CustomVirtualAudioNode from './VirtualAudioNodes/CustomVirtualAudioNode'
-import { VirtualAudioNode } from './types'
-
-export default (audioContext: AudioContext, [node, output, params, input]): VirtualAudioNode =>
-  typeof node === 'function'
-    ? new CustomVirtualAudioNode(audioContext, node, output, params)
-    : new StandardVirtualAudioNode(audioContext, node, output, params, input)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import VirtualAudioGraph from './VirtualAudioGraph'
 
+export * from './nodeFactories'
+
+export { default as createNode } from './createNode'
+
 export default (config?: {audioContext?: AudioContext, output?: AudioDestinationNode}) => {
   const audioContext = config && config.audioContext || new AudioContext
   const output = config && config.output || audioContext.destination

--- a/src/nodeFactories.ts
+++ b/src/nodeFactories.ts
@@ -1,0 +1,30 @@
+import StandardVirtualAudioNode from './VirtualAudioNodes/StandardVirtualAudioNode'
+import { Output } from './types'
+
+const createNodeConstructor = (nodeName: string) =>
+  (output: Output, ...rest: any[]): StandardVirtualAudioNode => {
+    if (nodeName === 'mediaStreamDestination') {
+      return new StandardVirtualAudioNode(nodeName)
+    }
+    if (output == null) {
+      throw new Error(`Output not specified for ${nodeName}`)
+    }
+    return new StandardVirtualAudioNode(nodeName, output, ...rest)
+  }
+
+export const analyser = createNodeConstructor('analyser')
+export const biquadFilter = createNodeConstructor('biquadFilter')
+export const bufferSource = createNodeConstructor('bufferSource')
+export const channelMerger = createNodeConstructor('channelMerger')
+export const channelSplitter = createNodeConstructor('channelSplitter')
+export const convolver = createNodeConstructor('convolver')
+export const delay = createNodeConstructor('delay')
+export const dynamicsCompressor = createNodeConstructor('dynamicsCompressor')
+export const gain = createNodeConstructor('gain')
+export const mediaElementSource = createNodeConstructor('mediaElementSource')
+export const mediaStreamDestination = createNodeConstructor('mediaStreamDestination')
+export const mediaStreamSource = createNodeConstructor('mediaStreamSource')
+export const oscillator = createNodeConstructor('oscillator')
+export const panner = createNodeConstructor('panner')
+export const stereoPanner = createNodeConstructor('stereoPanner')
+export const waveShaper = createNodeConstructor('waveShaper')

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,16 @@
 import CustomVirtualAudioNode from './VirtualAudioNodes/CustomVirtualAudioNode'
 import StandardVirtualAudioNode from './VirtualAudioNodes/StandardVirtualAudioNode'
 
+export interface AudioNodePropertyLookup {
+  [_: string]: any
+}
+
+export interface AudioNodeFactoryParam {
+  [_: string]: any
+}
+
+export type CustomVirtualAudioNodeFactory = (_: VirtualAudioNodeParams) => VirtualAudioNodeGraph
+
 export type Output = string
   | number
   | { key: string, destination: string }
@@ -9,5 +19,9 @@ export type Output = string
 export type VirtualAudioNode = CustomVirtualAudioNode | StandardVirtualAudioNode
 
 export interface VirtualAudioNodeGraph {
-  [key: string]: VirtualAudioNode
+  [_: string]: VirtualAudioNode
+}
+
+export interface VirtualAudioNodeParams {
+  [_: string]: any
 }

--- a/test/createVirtualAudioGraph.js
+++ b/test/createVirtualAudioGraph.js
@@ -1,8 +1,9 @@
 /* global AudioContext */
 const test = require('tape')
 require('./WebAudioTestAPISetup')
+const V = require('..')
+const createVirtualAudioGraph = V.default
 
-const createVirtualAudioGraph = require('..')
 const audioContext = new AudioContext()
 
 test('createVirtualAudioGraph - optionally takes audioContext property', t => {
@@ -16,7 +17,7 @@ test('createVirtualAudioGraph - optionally takes output parameter', t => {
   const gain = audioContext.createGain()
 
   createVirtualAudioGraph({audioContext, output: gain}).update({
-    0: ['gain', 'output', {gain: 0.2}],
+    0: V.gain('output', {gain: 0.2}),
   })
 
   t.deepEqual(gain.toJSON(), {
@@ -31,7 +32,7 @@ test('createVirtualAudioGraph - optionally takes output parameter', t => {
     name: 'GainNode',
   })
   createVirtualAudioGraph({audioContext}).update({
-    0: ['gain', 'output', {gain: 0.2}],
+    0: V.gain('output', {gain: 0.2}),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [

--- a/test/currentTime.js
+++ b/test/currentTime.js
@@ -1,7 +1,7 @@
 /* global AudioContext */
 const test = require('tape')
 require('./WebAudioTestAPISetup')
-const createVirtualAudioGraph = require('..')
+const createVirtualAudioGraph = require('..').default
 
 const audioContext = new AudioContext()
 test('virtualAudioGraph instance - has currentTime getter property', t => {

--- a/test/customNodes/expectedBehaviour.js
+++ b/test/customNodes/expectedBehaviour.js
@@ -7,16 +7,17 @@ const pingPongDelay = require('../utils/pingPongDelay')
 const sineOsc = require('../utils/sineOsc')
 const squareOsc = require('../utils/squareOsc')
 const twoGains = require('../utils/twoGains')
-const createVirtualAudioGraph = require('../..')
+const V = require('../..')
+const createVirtualAudioGraph = V.default
 
 const audioContext = new AudioContext()
 const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
 test('customNodes - creates a custom node which can be reused in virtualAudioGraph.update', t => {
   const virtualGraphParams = {
-    0: ['gain', 'output', {gain: 0.5}],
-    1: [pingPongDelay, 0, {decay: 0.5, delayTime: 0.5, maxDelayTime: 0.5}],
-    2: ['oscillator', 1],
+    0: V.gain('output', {gain: 0.5}),
+    1: pingPongDelay(0, {decay: 0.5, delayTime: 0.5, maxDelayTime: 0.5}),
+    2: V.oscillator(1),
   }
 
   t.deepEqual(virtualAudioGraph.update(virtualGraphParams), virtualAudioGraph)
@@ -31,17 +32,17 @@ test('customNodes - creates a custom node which can be reused in virtualAudioGra
 })
 
 test('customNodes - can define a custom node built of other custom nodes', t => {
-  const quietPingPongDelay = () => ({
-    0: ['gain', 'output'],
-    1: [pingPongDelay, 0],
-    2: ['oscillator', 1],
-  })
+  const quietPingPongDelay = V.createNode(() => ({
+    0: V.gain('output'),
+    1: pingPongDelay(0),
+    2: V.oscillator(1),
+  }))
 
   const virtualGraphParams = {
-    0: ['gain', 'output', {gain: 0.5}],
-    1: [quietPingPongDelay, 0],
-    2: [pingPongDelay, 1],
-    3: ['oscillator', 2],
+    0: V.gain('output', {gain: 0.5}),
+    1: quietPingPongDelay(0),
+    2: pingPongDelay(1),
+    3: V.oscillator(2),
   }
 
   t.deepEqual(virtualAudioGraph.update(virtualGraphParams), virtualAudioGraph)
@@ -51,17 +52,20 @@ test('customNodes - can define a custom node built of other custom nodes', t => 
 
 test('customNodes - can define a custom node which can be updated', t => {
   const virtualGraphParams = {
-    0: ['gain', 'output', {gain: 0.5}],
-    1: [pingPongDelay, 0, {decay: 0.5, delayTime: 0.5, maxDelayTime: 0.5}],
-    2: ['oscillator', 1],
+    0: V.gain('output', {gain: 0.5}),
+    1: pingPongDelay(0, {decay: 0.5, delayTime: 0.5, maxDelayTime: 0.5}),
+    2: V.oscillator(1),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
 
   t.deepEqual(audioContext.toJSON(), {name: 'AudioDestinationNode', inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'StereoPannerNode', pan: Object({value: 1, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: ['<circular:DelayNode>', Object({name: 'OscillatorNode', type: 'sine', frequency: Object({value: 440, inputs: []}), detune: Object({value: 0, inputs: []}), inputs: []})]})]})]})]})]}), Object({name: 'StereoPannerNode', pan: Object({value: -1, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: ['<circular:DelayNode>']})]}), Object({name: 'OscillatorNode', type: 'sine', frequency: Object({value: 440, inputs: []}), detune: Object({value: 0, inputs: []}), inputs: []})]})]})]})]})]})
 
-  virtualGraphParams[1][2].decay = 0.6
-  virtualAudioGraph.update(virtualGraphParams)
+  virtualAudioGraph.update({
+    0: V.gain('output', {gain: 0.5}),
+    1: pingPongDelay(0, {decay: 0.6, delayTime: 0.5, maxDelayTime: 0.5}),
+    2: V.oscillator(1),
+  })
 
   t.deepEqual(audioContext.toJSON(), {name: 'AudioDestinationNode', inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'StereoPannerNode', pan: Object({value: 1, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.6, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.6, inputs: []}), inputs: ['<circular:DelayNode>', Object({name: 'OscillatorNode', type: 'sine', frequency: Object({value: 440, inputs: []}), detune: Object({value: 0, inputs: []}), inputs: []})]})]})]})]})]}), Object({name: 'StereoPannerNode', pan: Object({value: -1, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.6, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.6, inputs: []}), inputs: ['<circular:DelayNode>']})]}), Object({name: 'OscillatorNode', type: 'sine', frequency: Object({value: 440, inputs: []}), detune: Object({value: 0, inputs: []}), inputs: []})]})]})]})]})]})
   t.end()
@@ -69,18 +73,16 @@ test('customNodes - can define a custom node which can be updated', t => {
 
 test('customNodes - can define a custom node which can be removed', t => {
   const virtualGraphParams = {
-    0: ['gain', 'output', {gain: 0.5}],
-    1: [pingPongDelay, 0, {decay: 0.5, delayTime: 0.5, maxDelayTime: 0.5}],
-    2: ['oscillator', 1],
+    0: V.gain('output', {gain: 0.5}),
+    1: pingPongDelay(0, {decay: 0.5, delayTime: 0.5, maxDelayTime: 0.5}),
+    2: V.oscillator(1),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
 
   t.deepEqual(audioContext.toJSON(), {name: 'AudioDestinationNode', inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'StereoPannerNode', pan: Object({value: 1, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: ['<circular:DelayNode>', Object({name: 'OscillatorNode', type: 'sine', frequency: Object({value: 440, inputs: []}), detune: Object({value: 0, inputs: []}), inputs: []})]})]})]})]})]}), Object({name: 'StereoPannerNode', pan: Object({value: -1, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'DelayNode', delayTime: Object({value: 0.5, inputs: []}), inputs: [Object({name: 'GainNode', gain: Object({value: 0.5, inputs: []}), inputs: ['<circular:DelayNode>']})]}), Object({name: 'OscillatorNode', type: 'sine', frequency: Object({value: 440, inputs: []}), detune: Object({value: 0, inputs: []}), inputs: []})]})]})]})]})]})
 
-  virtualGraphParams[1][2].decay = 0.6
-
-  virtualAudioGraph.update({0: ['gain', 'output', {gain: 0.5}]})
+  virtualAudioGraph.update({0: V.gain('output', {gain: 0.5})})
 
   t.deepEqual(audioContext.toJSON(), {
     inputs: [{
@@ -95,43 +97,43 @@ test('customNodes - can define a custom node which can be removed', t => {
 
 test('customNodes - can define a custom node which can be replaced with another on update', t => {
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: 0.5}],
-    1: [squareOsc, 0, {
+    0: V.gain('output', {gain: 0.5}),
+    1: squareOsc(0, {
       frequency: 220,
       gain: 0.5,
       startTime: 1,
       stopTime: 2,
-    }],
+    }),
   })
 
   t.deepEqual(audioContext.toJSON(), {name: 'AudioDestinationNode', inputs: [{name: 'GainNode', gain: {value: 0.5, inputs: []}, inputs: [{name: 'GainNode', gain: {value: 0.5, inputs: []}, inputs: [{name: 'OscillatorNode', type: 'square', frequency: {value: 220, inputs: []}, detune: {value: 0, inputs: []}, inputs: []}, {name: 'OscillatorNode', type: 'square', frequency: {value: 220, inputs: []}, detune: {value: 3, inputs: []}, inputs: []}]}]}]})
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: 0.5}],
-    1: [sineOsc, 0, {
+    0: V.gain('output', {gain: 0.5}),
+    1: sineOsc(0, {
       frequency: 220,
       gain: 0.5,
       startTime: 1,
       stopTime: 2,
-    }],
+    }),
   })
 
   t.deepEqual(audioContext.toJSON(), {name: 'AudioDestinationNode', inputs: [{name: 'GainNode', gain: {value: 0.5, inputs: []}, inputs: [{name: 'GainNode', gain: {value: 0.5, inputs: []}, inputs: [{name: 'OscillatorNode', type: 'sine', frequency: {value: 220, inputs: []}, detune: {value: 0, inputs: []}, inputs: []}]}]}]})
 
   const sampleRate = audioContext.sampleRate
   const buffer = audioContext.createBuffer(2, sampleRate * 2, sampleRate)
-  const reverb1 = () => ({
-    0: ['gain', 'output'],
-    1: ['convolver', 0, {buffer}, 'input'],
-  })
-  const reverb2 = () => ({
-    0: ['gain', 'output', {gain: 0.5}],
-    1: ['convolver', 0, {buffer}, 'input'],
-  })
+  const reverb1 = V.createNode(() => ({
+    0: V.gain('output'),
+    1: V.convolver(0, {buffer}, 'input'),
+  }))
+  const reverb2 = V.createNode(() => ({
+    0: V.gain('output', {gain: 0.5}),
+    1: V.convolver(0, {buffer}, 'input'),
+  }))
 
   virtualAudioGraph.update({
-    0: [reverb1, 'output'],
-    1: ['gain', 0],
+    0: reverb1('output'),
+    1: V.gain(0),
   })
 
   t.deepEqual(audioContext.toJSON(), {
@@ -151,8 +153,8 @@ test('customNodes - can define a custom node which can be replaced with another 
   })
 
   virtualAudioGraph.update({
-    0: [reverb2, 'output'],
-    1: ['gain', 0],
+    0: reverb2('output'),
+    1: V.gain(0),
   })
 
   t.deepEqual(audioContext.toJSON(), {
@@ -175,13 +177,13 @@ test('customNodes - can define a custom node which can be replaced with another 
 
 test('customNodes - can define a custom node which has an input node with no params', t => {
   virtualAudioGraph.update({
-    0: [gainWithNoParams, 'output'],
-    1: [sineOsc, 0, {
+    0: gainWithNoParams('output'),
+    1: sineOsc(0, {
       frequency: 220,
       gain: 0.5,
       startTime: 1,
       stopTime: 2,
-    }],
+    }),
   })
   t.deepEqual(
     audioContext.toJSON(),
@@ -219,35 +221,32 @@ test('customNodes - can define custom nodes which can be reordered', t => {
   }
 
   virtualAudioGraph.update({
-    'channel:0-type:effect-id:0': ['gain', 'output'],
-    'channel:0-type:effect-id:1': [twoGains, 'channel:0-type:effect-id:0'],
-    'channel:[0]-type:source-id:keyboard: 7': [
-      sineOsc,
+    'channel:0-type:effect-id:0': V.gain('output'),
+    'channel:0-type:effect-id:1': twoGains('channel:0-type:effect-id:0'),
+    'channel:[0]-type:source-id:keyboard: 7': sineOsc(
       ['channel:0-type:effect-id:1'],
       {frequency: 500, gain: 0.3},
-    ],
+    ),
   })
   t.deepEqual(audioContext.toJSON(), expectedData)
 
   virtualAudioGraph.update({
-    'channel:0-type:effect-id:0': ['gain', 'channel:0-type:effect-id:1'],
-    'channel:0-type:effect-id:1': [twoGains, 'output'],
-    'channel:[0]-type:source-id:keyboard: 5': [
-      sineOsc,
+    'channel:0-type:effect-id:0': V.gain('channel:0-type:effect-id:1'),
+    'channel:0-type:effect-id:1': twoGains('output'),
+    'channel:[0]-type:source-id:keyboard: 5': sineOsc(
       ['channel:0-type:effect-id:0'],
       {frequency: 500, gain: 0.3},
-    ],
+    ),
   })
   t.deepEqual(audioContext.toJSON(), expectedData)
 
   virtualAudioGraph.update({
-    'channel:0-type:effect-id:0': ['gain', 'output'],
-    'channel:0-type:effect-id:1': [twoGains, 'channel:0-type:effect-id:0'],
-    'channel:[0]-type:source-id:keyboard: 7': [
-      sineOsc,
+    'channel:0-type:effect-id:0': V.gain('output'),
+    'channel:0-type:effect-id:1': twoGains('channel:0-type:effect-id:0'),
+    'channel:[0]-type:source-id:keyboard: 7': sineOsc(
       ['channel:0-type:effect-id:1'],
       {frequency: 500, gain: 0.3},
-    ],
+    ),
   })
   t.deepEqual(audioContext.toJSON(), expectedData)
   t.end()

--- a/test/getAudioNodeById.js
+++ b/test/getAudioNodeById.js
@@ -1,13 +1,14 @@
 /* global AudioContext GainNode */
-require('./WebAudioTestAPISetup')
 const test = require('tape')
-const createVirtualAudioGraph = require('..')
+require('./WebAudioTestAPISetup')
+const V = require('..')
+const createVirtualAudioGraph = V.default
 
 test('virtualAudioGraph instance - getAudioNodeById', t => {
   const audioContext = new AudioContext()
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
-  virtualAudioGraph.update({0: ['gain', 'output']})
+  virtualAudioGraph.update({0: V.gain('output')})
 
   t.is(virtualAudioGraph.getAudioNodeById(0).constructor, GainNode)
   t.end()

--- a/test/nodeFactories.js
+++ b/test/nodeFactories.js
@@ -1,0 +1,99 @@
+const test = require('tape')
+const {
+  analyser,
+  biquadFilter,
+  bufferSource,
+  channelMerger,
+  channelSplitter,
+  convolver,
+  delay,
+  dynamicsCompressor,
+  gain,
+  mediaElementSource,
+  mediaStreamDestination,
+  mediaStreamSource,
+  oscillator,
+  panner,
+  stereoPanner,
+  waveShaper,
+} = require('..')
+
+test('analyser', t => {
+  t.throws(() => analyser(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('biquadFilter', t => {
+  t.throws(() => biquadFilter(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('bufferSource', t => {
+  t.throws(() => bufferSource(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('channelMerger', t => {
+  t.throws(() => channelMerger(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('channelSplitter', t => {
+  t.throws(() => channelSplitter(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('convolver', t => {
+  t.throws(() => convolver(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('delay', t => {
+  t.throws(() => delay(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('dynamicsCompressor', t => {
+  t.throws(() => dynamicsCompressor(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('gain', t => {
+  t.throws(() => gain(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('mediaElementSource', t => {
+  t.throws(() => mediaElementSource(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('mediaStreamDestination', t => {
+  t.doesNotThrow(() => mediaStreamDestination(), 'does not throw an error when no output is provided')
+  t.end()
+})
+
+test('mediaStreamSource', t => {
+  t.throws(() => mediaStreamSource(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('oscillator', t => {
+  t.throws(() => oscillator(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('panner', t => {
+  t.throws(() => panner(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('stereoPanner', t => {
+  t.throws(() => stereoPanner(), 'throws an error when no output is provided')
+  t.end()
+})
+
+test('waveShaper', t => {
+  t.throws(() => waveShaper(), 'throws an error when no output is provided')
+  t.end()
+})

--- a/test/update/audioParamMethods.js
+++ b/test/update/audioParamMethods.js
@@ -1,22 +1,26 @@
 /* global AudioContext */
 const test = require('tape')
 require('../WebAudioTestAPISetup')
-const createVirtualAudioGraph = require('../..')
+const V = require('../..')
+const createVirtualAudioGraph = V.default
 
 test('update - single setValueAtTime', t => {
   const audioContext = new AudioContext()
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: ['setValueAtTime', 0.5, 1]}],
+    0: V.gain('output', {gain: ['setValueAtTime', 0.5, 1]}),
   })
+
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
       {gain: {inputs: [], value: 1}, inputs: [], name: 'GainNode'},
     ],
     name: 'AudioDestinationNode',
   })
+
   const gain = virtualAudioGraph.getAudioNodeById(0).gain
+
   t.is(gain.$valueAtTime('00:00.000'), 1)
   t.is(gain.$valueAtTime('00:00.999'), 1)
   t.is(gain.$valueAtTime('00:01.000'), 0.5)
@@ -29,19 +33,24 @@ test('update - multiple setValueAtTime', t => {
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
-      ['setValueAtTime', 0, 0],
-      ['setValueAtTime', 1, 1],
-      ['setValueAtTime', 0.5, 2],
-    ]}],
+    0: V.gain('output', {
+      gain: [
+        ['setValueAtTime', 0, 0],
+        ['setValueAtTime', 1, 1],
+        ['setValueAtTime', 0.5, 2],
+      ],
+    }),
   })
+
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
       {gain: {inputs: [], value: 0}, inputs: [], name: 'GainNode'},
     ],
     name: 'AudioDestinationNode',
   })
+
   const gain = virtualAudioGraph.getAudioNodeById(0).gain
+
   t.is(gain.$valueAtTime('00:00.000'), 0)
   t.is(gain.$valueAtTime('00:00.999'), 0)
   t.is(gain.$valueAtTime('00:01.000'), 1)
@@ -56,33 +65,41 @@ test('update - overides setValueAtTime', t => {
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: ['setValueAtTime', 0.5, 1]}],
+    0: V.gain('output', {gain: ['setValueAtTime', 0.5, 1]}),
   })
+
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
       {gain: {inputs: [], value: 1}, inputs: [], name: 'GainNode'},
     ],
     name: 'AudioDestinationNode',
   })
+
   const gain = virtualAudioGraph.getAudioNodeById(0).gain
+
   t.is(gain.$valueAtTime('00:00.000'), 1)
   t.is(gain.$valueAtTime('00:00.999'), 1)
   t.is(gain.$valueAtTime('00:01.000'), 0.5)
   t.is(gain.$valueAtTime('23:59.999'), 0.5)
+
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: ['setValueAtTime', 0.75, 0.5]}],
+    0: V.gain('output', {gain: ['setValueAtTime', 0.75, 0.5]}),
   })
+
   t.is(gain.$valueAtTime('00:00.000'), 1)
   t.is(gain.$valueAtTime('00:00.499'), 1)
   t.is(gain.$valueAtTime('00:00.500'), 0.75)
   t.is(gain.$valueAtTime('23:59.999'), 0.75)
+
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: ['setValueAtTime', 0.75, 1]}],
+    0: V.gain('output', {gain: ['setValueAtTime', 0.75, 1]}),
   })
+
   t.is(gain.$valueAtTime('00:00.000'), 1)
   t.is(gain.$valueAtTime('00:00.999'), 1)
   t.is(gain.$valueAtTime('00:01.000'), 0.75)
   t.is(gain.$valueAtTime('23:59.999'), 0.75)
+
   t.end()
 })
 
@@ -91,24 +108,28 @@ test('update - setValueAtTime with linearRampToValueAtTime', t => {
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
+    0: V.gain('output', {gain: [
       ['setValueAtTime', 0.25, 0.25],
       ['linearRampToValueAtTime', 0.5, 0.5],
-    ]}],
+    ]}),
   })
+
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
+    0: V.gain('output', {gain: [
       ['setValueAtTime', 0, 0],
       ['linearRampToValueAtTime', 1, 1],
-    ]}],
+    ]}),
   })
+
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
       {gain: {inputs: [], value: 0}, inputs: [], name: 'GainNode'},
     ],
     name: 'AudioDestinationNode',
   })
+
   const gain = virtualAudioGraph.getAudioNodeById(0).gain
+
   t.is(gain.$valueAtTime('00:00.000'), 0)
   t.is(gain.$valueAtTime('00:00.001'), 0.001)
   t.is(gain.$valueAtTime('00:00.250'), 0.25)
@@ -117,6 +138,7 @@ test('update - setValueAtTime with linearRampToValueAtTime', t => {
   t.is(gain.$valueAtTime('00:00.999'), 0.999)
   t.is(gain.$valueAtTime('00:01.000'), 1)
   t.is(gain.$valueAtTime('23:59.999'), 1)
+
   t.end()
 })
 
@@ -125,30 +147,32 @@ test('update - setValueAtTime with exponentialRampToValueAtTime', t => {
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
   virtualAudioGraph.update({
-    0: ['oscillator', 'output', {frequency: [
+    0: V.oscillator('output', {frequency: [
       ['setValueAtTime', 220, 0],
       ['exponentialRampToValueAtTime', 1320, 5],
-    ]}],
+    ]}),
   })
+
   virtualAudioGraph.update({
-    0: ['oscillator', 'output', {frequency: [
+    0: V.oscillator('output', {frequency: [
       ['setValueAtTime', 440, 0],
       ['exponentialRampToValueAtTime', 880, 1],
-    ]}],
+    ]}),
   })
+
   t.deepEqual(audioContext.toJSON(), {
-    inputs: [
-      {
-        detune: {inputs: [], value: 0},
-        frequency: {inputs: [], value: 440},
-        inputs: [],
-        name: 'OscillatorNode',
-        type: 'sine',
-      },
-    ],
+    inputs: [{
+      detune: {inputs: [], value: 0},
+      frequency: {inputs: [], value: 440},
+      inputs: [],
+      name: 'OscillatorNode',
+      type: 'sine',
+    }],
     name: 'AudioDestinationNode',
   })
+
   const frequency = virtualAudioGraph.getAudioNodeById(0).frequency
+
   t.is(frequency.$valueAtTime('00:00.000'), 440)
   t.is(frequency.$valueAtTime('00:00.001'), 440.30509048353554)
   t.is(frequency.$valueAtTime('00:00.250'), 523.2511306011972)
@@ -157,6 +181,7 @@ test('update - setValueAtTime with exponentialRampToValueAtTime', t => {
   t.is(frequency.$valueAtTime('00:00.999'), 879.3902418315982)
   t.is(frequency.$valueAtTime('00:01.000'), 880)
   t.is(frequency.$valueAtTime('23:59.999'), 880)
+
   t.end()
 })
 
@@ -165,24 +190,28 @@ test('update - setValueAtTime with setTargetAtTime', t => {
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
+    0: V.gain('output', {gain: [
       ['setValueAtTime', 0, 0],
       ['setTargetAtTime', 1, 1, 0.75],
-    ]}],
+    ]}),
   })
+
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
+    0: V.gain('output', {gain: [
       ['setValueAtTime', 0, 0],
       ['setTargetAtTime', 1, 1, 0.5],
-    ]}],
+    ]}),
   })
+
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
       {gain: {inputs: [], value: 0}, inputs: [], name: 'GainNode'},
     ],
     name: 'AudioDestinationNode',
   })
+
   const gain = virtualAudioGraph.getAudioNodeById(0).gain
+
   t.is(gain.$valueAtTime('00:00.000'), 0)
   t.is(gain.$valueAtTime('00:01.000'), 0)
   t.is(gain.$valueAtTime('00:01.100'), 0.1812692469220183)
@@ -193,6 +222,7 @@ test('update - setValueAtTime with setTargetAtTime', t => {
   t.is(gain.$valueAtTime('00:13.000'), 0.9999999999622486)
   t.is(gain.$valueAtTime('01:00.000'), 1)
   t.is(gain.$valueAtTime('23:59.999'), 1)
+
   t.end()
 })
 
@@ -201,25 +231,30 @@ test('update - setValueAtTime with setValueCurveAtTime', t => {
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
   const waveArray0 = Float32Array.of(0, 0.2, 0.4, 0.8)
+
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
+    0: V.gain('output', {gain: [
       ['setValueAtTime', 0, 0],
       ['setValueCurveAtTime', waveArray0, 1, 1],
-    ]}],
+    ]}),
   })
+
   const waveArray1 = Float32Array.of(0.5, 0.75, 0.25, 1)
+
   virtualAudioGraph.update({
-    0: ['gain', 'output', {gain: [
+    0: V.gain('output', {gain: [
       ['setValueAtTime', 0, 0],
       ['setValueCurveAtTime', waveArray1, 1, 1],
-    ]}],
+    ]}),
   })
+
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
       {gain: {inputs: [], value: 0}, inputs: [], name: 'GainNode'},
     ],
     name: 'AudioDestinationNode',
   })
+
   const gain = virtualAudioGraph.getAudioNodeById(0).gain
   t.is(gain.$valueAtTime('00:00.000'), 0)
   t.is(gain.$valueAtTime('00:00.999'), 0)

--- a/test/update/creatingAudioNodes.js
+++ b/test/update/creatingAudioNodes.js
@@ -9,7 +9,8 @@
 */
 const test = require('tape')
 require('../WebAudioTestAPISetup')
-const createVirtualAudioGraph = require('../..')
+const V = require('../..')
+const createVirtualAudioGraph = V.default
 
 test('update - creates AnalyserNode with all valid parameters', t => {
   const audioContext = new AudioContext()
@@ -23,7 +24,7 @@ test('update - creates AnalyserNode with all valid parameters', t => {
   }
 
   const virtualGraphParams = {
-    0: ['analyser', 'output', params],
+    0: V.analyser('output', params),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -51,7 +52,7 @@ test('update - creates BiquadFilterNode with all valid parameters', t => {
   const Q = 0.5
 
   const virtualGraphParams = {
-    0: ['biquadFilter', 'output', {detune, frequency, Q, type}],
+    0: V.biquadFilter('output', {detune, frequency, Q, type}),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -79,7 +80,7 @@ test('update - creates BufferSourceNode with all valid parameters', t => {
   }
 
   const virtualGraphParams = {
-    0: ['bufferSource', 'output', params],
+    0: V.bufferSource('output', params),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -100,19 +101,19 @@ test('update - creates ChannelSplitterNode and ChannelMergerNode and connects th
   const params = {numberOfOutputs: 2}
 
   virtualAudioGraph.update({
-    0: ['channelMerger', 'output', params],
+    0: V.channelMerger('output', params),
   })
   t.is(virtualAudioGraph.getAudioNodeById(0).constructor.name, 'ChannelMergerNode')
 
   virtualAudioGraph.update({
-    0: ['channelSplitter', 'output', params],
+    0: V.channelSplitter('output', params),
   })
   t.is(virtualAudioGraph.getAudioNodeById(0).constructor.name, 'ChannelSplitterNode')
 
   virtualAudioGraph.update({
-    0: ['channelMerger', 'output', params],
-    1: ['oscillator', 'output'],
-    2: ['channelSplitter', {inputs: [1, 0], key: 0, outputs: [0, 1]}, params],
+    0: V.channelMerger('output', params),
+    1: V.oscillator('output'),
+    2: V.channelSplitter({inputs: [1, 0], key: 0, outputs: [0, 1]}, params),
   })
   t.end()
 })
@@ -127,7 +128,7 @@ test('update - creates ConvolverNode with all valid parameters', t => {
   }
 
   const virtualGraphParams = {
-    0: ['convolver', 'output', params],
+    0: V.convolver('output', params),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -145,7 +146,7 @@ test('update - creates DelayNode with all valid parameters', t => {
   const maxDelayTime = 5
 
   const virtualGraphParams = {
-    0: ['delay', 'output', {delayTime, maxDelayTime}],
+    0: V.delay('output', {delayTime, maxDelayTime}),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -168,7 +169,7 @@ test('update - creates DynamicsCompressorNode with all valid parameters', t => {
   }
 
   const virtualGraphParams = {
-    'random string id': ['dynamicsCompressor', 'output', params],
+    'random string id': V.dynamicsCompressor('output', params),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -189,7 +190,7 @@ test('update - creates GainNode with all valid parameters', t => {
   const gain = 0.5
 
   const virtualGraphParams = {
-    0: ['gain', 'output', {gain}],
+    0: V.gain('output', {gain}),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -204,7 +205,7 @@ test('update - creates MediaStreamAudioDestinationNode with all valid parameters
   const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
   virtualAudioGraph.update({
-    0: ['mediaStreamDestination'],
+    0: V.mediaStreamDestination(),
   })
   const audioNode = virtualAudioGraph.getAudioNodeById(0)
   t.is(audioNode.constructor.name, 'MediaStreamAudioDestinationNode')
@@ -218,12 +219,12 @@ test('update - creates MediaElementAudioSourceNode and MediaStreamAudioSourceNod
   const MediaStream = WebAudioTestAPI.MediaStream
 
   virtualAudioGraph.update({
-    0: ['mediaElementSource', 'output', {mediaElement: new HTMLMediaElement()}],
+    0: V.mediaElementSource('output', {mediaElement: new HTMLMediaElement()}),
   })
   t.is(virtualAudioGraph.getAudioNodeById(0).constructor.name, 'MediaElementAudioSourceNode')
 
   virtualAudioGraph.update({
-    0: ['mediaStreamSource', 'output', {mediaStream: new MediaStream()}],
+    0: V.mediaStreamSource('output', {mediaStream: new MediaStream()}),
   })
   t.is(virtualAudioGraph.getAudioNodeById(0).constructor.name, 'MediaStreamAudioSourceNode')
   t.end()
@@ -239,7 +240,7 @@ test('update - creates OscillatorNode with all valid parameters', t => {
   }
 
   const virtualGraphParams = {
-    0: ['oscillator', 'output', params],
+    0: V.oscillator('output', params),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -266,7 +267,7 @@ test('update - creates PannerNode with all valid parameters', t => {
   const orientation = [1, 0, 0]
 
   const virtualGraphParams = {
-    0: ['panner', 'output', {
+    0: V.panner('output', {
       coneInnerAngle,
       coneOuterAngle,
       coneOuterGain,
@@ -277,7 +278,7 @@ test('update - creates PannerNode with all valid parameters', t => {
       position,
       refDistance,
       rolloffFactor,
-    }],
+    }),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -300,7 +301,7 @@ test('update - creates StereoPannerNode with all valid parameters', t => {
   const pan = 1
 
   const virtualGraphParams = {
-    0: ['stereoPanner', 'output', {pan}],
+    0: V.stereoPanner('output', {pan}),
   }
 
   virtualAudioGraph.update(virtualGraphParams)
@@ -319,7 +320,7 @@ test('update - creates WaveShaperNode with all valid parameters', t => {
   }
 
   const virtualGraphParams = {
-    0: ['waveShaper', 'output', params],
+    0: V.waveShaper('output', params),
   }
 
   virtualAudioGraph.update(virtualGraphParams)

--- a/test/update/errorThrowing.js
+++ b/test/update/errorThrowing.js
@@ -1,33 +1,34 @@
 /* global AudioContext */
 const test = require('tape')
 require('../WebAudioTestAPISetup')
-const createVirtualAudioGraph = require('../..')
+const V = require('../..')
+const createVirtualAudioGraph = V.default
 
 const audioContext = new AudioContext()
 const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
 test('update - throws an error if no output is provided', t => {
-  t.throws(() => virtualAudioGraph.update({0: ['gain']}))
+  t.throws(() => virtualAudioGraph.update({0: V.gain()}))
   t.end()
 })
 
 test('update - throws an error when virtual node name property is not recognised', t => {
-  t.throws(() => virtualAudioGraph.update({0: ['foobar', 'output']}))
+  t.throws(() => virtualAudioGraph.update({0: V.foobar('output')}))
   t.end()
 })
 
 test('update - throws an error when id is "output"', t => {
-  t.throws(() => virtualAudioGraph.update({output: ['gain', 'output']}))
+  t.throws(() => virtualAudioGraph.update({output: V.gain('output')}))
   t.end()
 })
 
 test('update - throws an error when id is "output"', t => {
   t.throws(() => virtualAudioGraph.update({
-    0: ['oscillator', 'output'],
+    0: V.oscillator('output'),
     1: undefined,
   }))
   t.throws(() => virtualAudioGraph.update({
-    0: ['oscillator', 'output'],
+    0: V.oscillator('output'),
     1: null,
   }))
   t.end()
@@ -35,10 +36,10 @@ test('update - throws an error when id is "output"', t => {
 
 test('update - throws an error when output is an object and key is not specified', t => {
   t.throws(() => virtualAudioGraph.update({
-    0: ['gain', ['output'], {gain: 0.2}],
-    1: ['oscillator', 0, {frequency: 120}],
-    2: ['gain', {destination: 'frequency', id: 1}, {gain: 1024}],
-    3: ['oscillator', 2, {frequency: 100}],
+    0: V.gain(['output'], {gain: 0.2}),
+    1: V.oscillator(0, {frequency: 120}),
+    2: V.gain({destination: 'frequency', id: 1}, {gain: 1024}),
+    3: V.oscillator(2, {frequency: 100}),
   }))
   t.end()
 })
@@ -47,9 +48,9 @@ test('update - throws an error when output is an object and key is not specified
   const params = {numberOfOutputs: 2}
 
   t.throws(() => virtualAudioGraph.update({
-    0: ['channelMerger', 'output', params],
-    1: ['oscillator', 'output'],
-    2: ['channelSplitter', {inputs: [1, 0], key: 0, outputs: [0, 1, 2]}, params],
+    0: V.channelMerger('output', params),
+    1: V.oscillator('output'),
+    2: V.channelSplitter({inputs: [1, 0], key: 0, outputs: [0, 1, 2]}, params),
   }))
   t.end()
 })

--- a/test/update/expectedBehaviour.js
+++ b/test/update/expectedBehaviour.js
@@ -3,21 +3,22 @@ const test = require('tape')
 require('../WebAudioTestAPISetup')
 const pingPongDelay = require('../utils/pingPongDelay')
 const sineOsc = require('../utils/sineOsc')
-const createVirtualAudioGraph = require('../..')
+const V = require('../..')
+const createVirtualAudioGraph = V.default
 
 const audioContext = new AudioContext()
 const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 
 test('update - returns itself', t => {
-  const virtualNodeParams = {0: ['oscillator', 'output', {type: 'square'}]}
+  const virtualNodeParams = {0: V.oscillator('output', {type: 'square'})}
   t.is(virtualAudioGraph.update(virtualNodeParams), virtualAudioGraph)
   t.end()
 })
 
 test('update - adds then removes nodes', t => {
   virtualAudioGraph.update({
-    0: ['gain', 'output'],
-    1: ['oscillator', 0],
+    0: V.gain('output'),
+    1: V.oscillator(0),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [{
@@ -43,8 +44,8 @@ test('update - adds then removes nodes', t => {
 
 test('update - handles random strings for ids', t => {
   virtualAudioGraph.update({
-    bar: ['oscillator', 'foo'],
-    foo: ['gain', 'output'],
+    bar: V.oscillator('foo'),
+    foo: V.gain('output'),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [{
@@ -78,7 +79,7 @@ test('update - handles random strings for ids', t => {
 })
 
 test('update - handles random strings for ids', t => {
-  virtualAudioGraph.update({0: ['gain', 'output']})
+  virtualAudioGraph.update({0: V.gain('output')})
 
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
@@ -94,7 +95,7 @@ test('update - handles random strings for ids', t => {
     name: 'AudioDestinationNode',
   })
 
-  virtualAudioGraph.update({0: ['oscillator', 'output']})
+  virtualAudioGraph.update({0: V.oscillator('output')})
 
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
@@ -115,7 +116,7 @@ test('update - handles random strings for ids', t => {
     name: 'AudioDestinationNode',
   })
 
-  virtualAudioGraph.update({0: [pingPongDelay, 'output']})
+  virtualAudioGraph.update({0: pingPongDelay('output')})
 
   t.deepEqual(audioContext.toJSON(), {
     name: 'AudioDestinationNode', inputs: [
@@ -129,7 +130,7 @@ test('update - handles random strings for ids', t => {
 
 test('update - updates standard and custom nodes if passed same id but different params', t => {
   virtualAudioGraph.update({
-    0: ['oscillator', 'output', {detune: -9, frequency: 220}],
+    0: V.oscillator('output', {detune: -9, frequency: 220}),
   })
 
   t.deepEqual(audioContext.toJSON(), {
@@ -144,7 +145,7 @@ test('update - updates standard and custom nodes if passed same id but different
   })
 
   virtualAudioGraph.update({
-    0: ['oscillator', 'output', {detune: 0, frequency: 880}],
+    0: V.oscillator('output', {detune: 0, frequency: 880}),
   })
 
   t.deepEqual(audioContext.toJSON(), {
@@ -159,7 +160,7 @@ test('update - updates standard and custom nodes if passed same id but different
   })
 
   virtualAudioGraph.update({
-    0: [sineOsc, 'output', {frequency: 110, gain: 0.5}],
+    0: sineOsc('output', {frequency: 110, gain: 0.5}),
   })
 
   t.deepEqual(audioContext.toJSON(), {
@@ -178,7 +179,7 @@ test('update - updates standard and custom nodes if passed same id but different
   })
 
   virtualAudioGraph.update({
-    0: [sineOsc, 'output', {frequency: 660, gain: 0.2}],
+    0: sineOsc('output', {frequency: 660, gain: 0.2}),
   })
 
   t.deepEqual(audioContext.toJSON(), {
@@ -200,8 +201,8 @@ test('update - updates standard and custom nodes if passed same id but different
 
 test('update - connects nodes to each other', t => {
   virtualAudioGraph.update({
-    0: ['gain', 'output'],
-    1: ['oscillator', 0],
+    0: V.gain('output'),
+    1: V.oscillator(0),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
@@ -220,7 +221,7 @@ test('update - connects nodes to each other', t => {
     name: 'AudioDestinationNode',
   })
   virtualAudioGraph.update({
-    0: ['oscillator', 'output'],
+    0: V.oscillator('output'),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [{
@@ -237,8 +238,8 @@ test('update - connects nodes to each other', t => {
 
 test('update - reconnects nodes to each other', t => {
   virtualAudioGraph.update({
-    0: ['gain', 'output'],
-    1: ['oscillator', 0],
+    0: V.gain('output'),
+    1: V.oscillator(0),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [{
@@ -255,8 +256,8 @@ test('update - reconnects nodes to each other', t => {
     name: 'AudioDestinationNode',
   })
   virtualAudioGraph.update({
-    0: ['gain', 'output'],
-    1: ['oscillator', 'output'],
+    0: V.gain('output'),
+    1: V.oscillator('output'),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [
@@ -280,13 +281,12 @@ test('update - reconnects nodes to each other', t => {
 
 test('update - connects and reconnects nodes to audioParams', t => {
   virtualAudioGraph.update({
-    0: ['gain', 'output'],
-    1: ['oscillator', 0],
-    2: [
-      'oscillator',
+    0: V.gain('output'),
+    1: V.oscillator(0),
+    2: V.oscillator(
       {destination: 'frequency', key: 1},
       {frequency: 0.5, type: 'triangle'},
-    ],
+    ),
   })
 
   t.deepEqual(audioContext.toJSON(), {
@@ -314,13 +314,12 @@ test('update - connects and reconnects nodes to audioParams', t => {
   })
 
   virtualAudioGraph.update({
-    0: ['gain', 'output'],
-    1: ['oscillator', 0],
-    2: [
-      'oscillator',
+    0: V.gain('output'),
+    1: V.oscillator(0),
+    2: V.oscillator(
       [{destination: 'detune', key: 1}],
       {frequency: 0.5, type: 'triangle'},
-    ],
+    ),
   })
 
   t.deepEqual(audioContext.toJSON(), {
@@ -348,7 +347,7 @@ test('update - connects and reconnects nodes to audioParams', t => {
   })
 
   virtualAudioGraph.update({
-    0: ['oscillator', 'output'],
+    0: V.oscillator('output'),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [{
@@ -365,9 +364,9 @@ test('update - connects and reconnects nodes to audioParams', t => {
 
 test('update - disconnects and reconnects child nodes properly', t => {
   virtualAudioGraph.update({
-    0: ['gain', 'output'],
-    1: ['stereoPanner', 0],
-    2: ['gain', 1],
+    0: V.gain('output'),
+    1: V.stereoPanner(0),
+    2: V.gain(1),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [{
@@ -386,9 +385,9 @@ test('update - disconnects and reconnects child nodes properly', t => {
     name: 'AudioDestinationNode',
   })
   virtualAudioGraph.update({
-    0: ['gain', 'output'],
-    1: ['gain', 0],
-    2: ['gain', 1],
+    0: V.gain('output'),
+    1: V.gain(0),
+    2: V.gain(1),
   })
   t.deepEqual(audioContext.toJSON(), {
     inputs: [{

--- a/test/update/scheduling.js
+++ b/test/update/scheduling.js
@@ -1,7 +1,8 @@
 /* global AudioContext */
 const test = require('tape')
 require('../WebAudioTestAPISetup')
-const createVirtualAudioGraph = require('../..')
+const V = require('../..')
+const createVirtualAudioGraph = V.default
 
 const audioContext = new AudioContext()
 const virtualAudioGraph = createVirtualAudioGraph({audioContext})
@@ -9,8 +10,8 @@ const virtualAudioGraph = createVirtualAudioGraph({audioContext})
 const testSchedulingForNode = node => {
   test(`update - ${node}s with no start or stop times are played immediately and forever`, t => {
     const virtualGraphParams = {
-      0: [node, 'output'],
-      1: [node, 'output'],
+      0: V[node]('output'),
+      1: V[node]('output'),
     }
 
     virtualAudioGraph.update(virtualGraphParams)
@@ -28,8 +29,8 @@ const testSchedulingForNode = node => {
 
   test(`update - ${node}s with no start times but with stop times are played immediately until their stop time`, t => {
     const virtualGraphParams = {
-      0: [node, 'output', {stopTime: 0.2}],
-      1: [node, 'output', {stopTime: 0.2}],
+      0: V[node]('output', {stopTime: 0.2}),
+      1: V[node]('output', {stopTime: 0.2}),
     }
 
     virtualAudioGraph.update(virtualGraphParams)
@@ -47,8 +48,8 @@ const testSchedulingForNode = node => {
 
   test(`update - ${node}s with start times but no stop times are played at their start time then forever`, t => {
     const virtualGraphParams = {
-      0: [node, 'output', {startTime: 0.1}],
-      1: [node, 'output', {startTime: 0.1}],
+      0: V[node]('output', {startTime: 0.1}),
+      1: V[node]('output', {startTime: 0.1}),
     }
 
     virtualAudioGraph.update(virtualGraphParams)
@@ -66,7 +67,7 @@ const testSchedulingForNode = node => {
 
   test(`update - works when scheduling a single ${node}'s start and stop times`, t => {
     const virtualGraphParams = {
-      nodeA: [node, 'output', {startTime: 0.1, stopTime: 0.2}],
+      nodeA: V[node]('output', {startTime: 0.1, stopTime: 0.2}),
     }
 
     virtualAudioGraph.update(virtualGraphParams)
@@ -81,9 +82,9 @@ const testSchedulingForNode = node => {
 
   test(`update - works when scheduling multiple ${node}s' start and stop times`, t => {
     const virtualGraphParams = {
-      0: [node, 'output', {startTime: 0.1, stopTime: 0.2}],
-      1: [node, 'output', {startTime: 0.1, stopTime: 0.2}],
-      2: [node, 'output', {startTime: 0.1, stopTime: 0.2}],
+      0: V[node]('output', {startTime: 0.1, stopTime: 0.2}),
+      1: V[node]('output', {startTime: 0.1, stopTime: 0.2}),
+      2: V[node]('output', {startTime: 0.1, stopTime: 0.2}),
     }
 
     virtualAudioGraph.update(virtualGraphParams)
@@ -119,10 +120,10 @@ const testSchedulingForNode = node => {
     }
 
     virtualAudioGraph.update({
-      0: [node, 'output', {startTime: 1.1, stopTime: 1.2}],
-      1: [node, 'output', {startTime: 1.1, stopTime: 1.2}],
-      2: [node, 'output', {startTime: 1.1, stopTime: 1.2}],
-      3: [node, 'output', {startTime: 1.1, stopTime: 1.2}],
+      0: V[node]('output', {startTime: 1.1, stopTime: 1.2}),
+      1: V[node]('output', {startTime: 1.1, stopTime: 1.2}),
+      2: V[node]('output', {startTime: 1.1, stopTime: 1.2}),
+      3: V[node]('output', {startTime: 1.1, stopTime: 1.2}),
     })
     Array.from(virtualAudioGraph.virtualNodes).forEach(x => {
       const audioNode = x.audioNode
@@ -143,10 +144,10 @@ const testSchedulingForNode = node => {
     })
 
     virtualAudioGraph.update({
-      0: [node, 'output', {startTime: 0.1, stopTime: 0.2}],
-      1: [node, 'output', {startTime: 0.1, stopTime: 0.2}],
-      2: [node, 'output', {startTime: 0.1, stopTime: 0.2}],
-      3: [node, 'output', {startTime: 0.1, stopTime: 0.2}],
+      0: V[node]('output', {startTime: 0.1, stopTime: 0.2}),
+      1: V[node]('output', {startTime: 0.1, stopTime: 0.2}),
+      2: V[node]('output', {startTime: 0.1, stopTime: 0.2}),
+      3: V[node]('output', {startTime: 0.1, stopTime: 0.2}),
     })
 
     Array.from(virtualAudioGraph.virtualNodes).forEach(x => {

--- a/test/utils/gainWithNoParams.js
+++ b/test/utils/gainWithNoParams.js
@@ -1,3 +1,5 @@
-module.exports = () => ({
-  0: ['gain', 'output', null, 'input'],
-})
+const V = require('../..')
+
+module.exports = V.createNode(() => ({
+  0: V.gain('output', null, 'input'),
+}))

--- a/test/utils/pingPongDelay.js
+++ b/test/utils/pingPongDelay.js
@@ -1,15 +1,17 @@
-module.exports = x => {
+const V = require('../..')
+
+module.exports = V.createNode(x => {
   const params = x || {}
   const decay = params.decay || 1 / 3
   const delayTime = params.delayTime || 1 / 3
   const maxDelayTime = params.maxDelayTime || 1 / 3
 
   return {
-    1: ['stereoPanner', 'output', {pan: 1}],
-    2: ['delay', [1, 'five'], {delayTime, maxDelayTime}],
-    3: ['gain', 2, {gain: decay}],
-    4: ['delay', ['zero', 3], {delayTime, maxDelayTime}],
-    five: ['gain', 4, {gain: decay}, 'input'],
-    zero: ['stereoPanner', 'output', {pan: -1}],
+    1: V.stereoPanner('output', {pan: 1}),
+    2: V.delay([1, 'five'], {delayTime, maxDelayTime}),
+    3: V.gain(2, {gain: decay}),
+    4: V.delay(['zero', 3], {delayTime, maxDelayTime}),
+    five: V.gain(4, {gain: decay}, 'input'),
+    zero: V.stereoPanner('output', {pan: -1}),
   }
-}
+})

--- a/test/utils/sineOsc.js
+++ b/test/utils/sineOsc.js
@@ -1,16 +1,18 @@
-module.exports = params => {
+const V = require('../..')
+
+module.exports = V.createNode(params => {
   const frequency = params.frequency
   const gain = params.gain
   const startTime = params.startTime
   const stopTime = params.stopTime
 
   return {
-    0: ['gain', ['output'], {gain}],
-    1: ['oscillator', 0, {
+    0: V.gain(['output'], {gain}),
+    1: V.oscillator(0, {
       frequency,
       startTime,
       stopTime,
       type: 'sine',
-    }],
+    }),
   }
-}
+})

--- a/test/utils/squareOsc.js
+++ b/test/utils/squareOsc.js
@@ -1,23 +1,25 @@
-module.exports = params => {
+const V = require('../..')
+
+module.exports = V.createNode(params => {
   const frequency = params.frequency
   const gain = params.gain
   const startTime = params.startTime
   const stopTime = params.stopTime
 
   return {
-    0: ['gain', 'output', {gain}],
-    1: ['oscillator', 0, {
+    0: V.gain('output', {gain}),
+    1: V.oscillator(0, {
       frequency,
       startTime,
       stopTime,
       type: 'square',
-    }],
-    2: ['oscillator', 0, {
+    }),
+    2: V.oscillator(0, {
       detune: 3,
       frequency,
       startTime,
       stopTime,
       type: 'square',
-    }],
+    }),
   }
-}
+})

--- a/test/utils/twoGains.js
+++ b/test/utils/twoGains.js
@@ -1,4 +1,6 @@
-module.exports = () => ({
-  0: ['gain', 'output'],
-  1: ['gain', 0, {}, 'input'],
-})
+const V = require('../..')
+
+module.exports = V.createNode(() => ({
+  0: V.gain('output'),
+  1: V.gain(0, {}, 'input'),
+}))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "module": "es2015",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "outDir": "./esm/",
     "sourceMap": false,
     "target": "es5"

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
     "tslint-config-airbnb"
   ],
   "rules": {
+    "import-name": false,
     "no-increment-decrement": false,
     "no-this-assignment": false,
     "semicolon": [true, "never"]


### PR DESCRIPTION
__If merged this will be a breaking API change__

Revists the work from  #26 and takes inspiration from https://github.com/ohanhi/hyperscript-helpers

Instead of
```js
const graph = {
  0: ['gain', 'output', {gain: 0.2}],
  1: ['oscillator', 0, {
    type: 'square',
    frequency: 440,
    startTime: currentTime + 1,
    stopTime: currentTime + 2
  }],
  2: ['oscillator', 0, {
    type: 'sawtooth',
    frequency: 660,
    detune: 4,
    startTime: currentTime + 1.5,
    stopTime: currentTime + 2.5
  }],
}
```
We now have
```js
const graph = {
  0: gain('output', {gain: 0.2}),
  1: oscillator(0, {
    type: 'square',
    frequency: 440,
    startTime: currentTime + 1,
    stopTime: currentTime + 2
  }),
  2: oscillator(0, {
    type: 'sawtooth',
    frequency: 660,
    detune: 4,
    startTime: currentTime + 1.5,
    stopTime: currentTime + 2.5
  }),
}
```

And custom nodes must now be created with the `createNode` function