### PR TITLE
enable strict typing on custom nodes

### DIFF
--- a/src/createNode.ts
+++ b/src/createNode.ts
@@ -5,7 +5,7 @@ import {
 } from "./types";
 import CustomVirtualAudioNode from "./VirtualAudioNodes/CustomVirtualAudioNode";
 
-export default (node: CustomVirtualAudioNodeFactory) => (
-  output: Output,
-  params?: IVirtualAudioNodeParams
-) => new CustomVirtualAudioNode(node, output, params);
+export default <P = IVirtualAudioNodeParams>(
+  node: CustomVirtualAudioNodeFactory<P>
+) => (output: Output, params?: P) =>
+  new CustomVirtualAudioNode(node, output, params);

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,8 @@ export interface IAudioNodeFactoryParam {
   [_: string]: any;
 }
 
-export type CustomVirtualAudioNodeFactory = (
-  _: IVirtualAudioNodeParams
+export type CustomVirtualAudioNodeFactory<P = IVirtualAudioNodeParams> = (
+  _: P
 ) => IVirtualAudioNodeGraph;
 
 interface IOutputObject {


### PR DESCRIPTION
using the latest version of `typescript` and `virtual-audio-graph`, given the following custom node:

```click.ts
import { gain, createNode, oscillator } from "virtual-audio-graph";

const click = createNode(({ mute, stopTime }) => ({
  mute: gain("output", { gain: mute ? 0 : 1 }),
  source: oscillator("mute", { stopTime }),
}));

click("output", { mute: false, stopTime: 1 });
```

everything works as expected at runtime, but because of the loose type definitions for `createNode` and `CustomVirtualAudioNodeFactory`:
- param types are not known from inside the node factory
- param types are not known when instantiating a node

if we try to type the factory, like so:

```click.ts
interface ClickParams {
  mute: boolean;
  stopTime: number;
}

const click = createNode(({ mute, stopTime }: ClickParams) => ({
  mute: gain("output", { gain: mute ? 0 : 1 }),
  source: oscillator("mute", { stopTime }),
}));
```

we are presented with the following error:

```
Argument of type '({ mute, stopTime }: ClickParams) => { mute: StandardVirtualAudioNode; source: StandardVirtualAudioNode; }' is not assignable to parameter of type 'CustomVirtualAudioNodeFactory'.
  Types of parameters '__0' and '_' are incompatible.
    Type 'IVirtualAudioNodeParams' is missing the following properties from type 'ClickParams': mute, stopTime

ts(2345)
```

a simple solution is to provide a generic on `createNode` that infers from the factory definition.

this fixes the above and also enables the form:

```click.ts
const click = createNode<ClickParams>(({ mute, stopTime }) => ({
  mute: gain("output", { gain: mute ? 0 : 1 }),
  source: oscillator("mute", { stopTime }),
}));
```